### PR TITLE
Add framework for unit tests

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^LICENSE\.md$
 ^\.travis\.yml$
 ^README\.Rmd$
+^codecov\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@
 language: R
 sudo: false
 cache: packages
+
+r_packages:
+  - covr
+
+after_success:
+  - Rscript -e 'library(covr); codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,5 @@ language: R
 sudo: false
 cache: packages
 
-r_packages:
-  - covr
-
 after_success:
-  - Rscript -e 'library(covr); codecov()'
+  - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,3 +20,5 @@ Imports:
     tibble (>= 1.3.4),
     lubridate (>= 1.7.1)
 RoxygenNote: 6.0.1
+Suggests: 
+    testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,5 @@ Imports:
     lubridate (>= 1.7.1)
 RoxygenNote: 6.0.1
 Suggests: 
-    testthat
+    testthat,
+    covr

--- a/README.Rmd
+++ b/README.Rmd
@@ -4,6 +4,7 @@ output: github_document
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 [![Travis build status](https://travis-ci.org/mikmart/pinr.svg?branch=master)](https://travis-ci.org/mikmart/pinr)
+[![Coverage status](https://codecov.io/gh/mikmart/pinr/branch/master/graph/badge.svg)](https://codecov.io/github/mikmart/pinr?branch=master)
 
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-[![Travis build status](https://travis-ci.org/mikmart/pinr.svg?branch=master)](https://travis-ci.org/mikmart/pinr)
+[![Travis build status](https://travis-ci.org/mikmart/pinr.svg?branch=master)](https://travis-ci.org/mikmart/pinr) [![Coverage status](https://codecov.io/gh/mikmart/pinr/branch/master/graph/badge.svg)](https://codecov.io/github/mikmart/pinr?branch=master)
 
 pinr
 ====

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(pinr)
+
+test_check("pinr")

--- a/tests/testthat/test-is_probably_pin.R
+++ b/tests/testthat/test-is_probably_pin.R
@@ -1,0 +1,6 @@
+context("test-is_probably_pin.R")
+
+test_that("valid pins are identified", {
+  # test pin from: http://vrk.fi/en/personal-identity-code1
+  expect_true(is_probably_pin("131052-308T"))
+})


### PR DESCRIPTION
Implements **testthat** unit test structure. Sets up test coverage tracking with codecov.io. Starts to address #3 by adding first unit test for PIN detection heuristic.