### PR TITLE
Allow manual renaming while retaining pins (Closes #7)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports: 
-    dplyr (>= 0.7.4),
     purrr (>= 0.2.4),
     stringr (>= 1.2.0),
     tibble (>= 1.3.4),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,3 +7,6 @@
 * The `drop_pin` argument in `pseudonymize()` has been renamed to `remove`. This
 is more consistent with names of arguments with similar functionality in other
 packages (such as `separate` and `unite` in **tidyr**).
+
+* When removing pin columns, now nothing gets suffixed and manual renames are
+applied. When retaining pin columns, pseudonymized columns that are not manually renamed gain the  `pid_suffix`.

--- a/tests/testthat/test-pseudonymize.R
+++ b/tests/testthat/test-pseudonymize.R
@@ -21,6 +21,20 @@ test_that("can pass data frame as key", {
   expect_equal(pseudonymize(df, key_df, pin)$pin, c(1, 1, 2))
 })
 
+test_that("can retain pin columns", {
+  out1 <- pseudonymize(df, key, pin, remove = FALSE)
+
+  expect_equal(out1$pin, df$pin)
+  expect_equal(out1$pin_pid, c(1, 1, 2))
+})
+
+test_that("can manually name new column when retaining pin", {
+  out2 <- pseudonymize(df, key, pid = pin, remove = FALSE)
+
+  expect_equal(out2$pin, df$pin)
+  expect_equal(out2$pid, c(1, 1, 2))
+})
+
 test_that("missing selection warns and returns data unchanged", {
   expect_warning({
     expect_equal(pseudonymize(df, key), df)


### PR DESCRIPTION
Naming behaviour is now consistent:

-  Manual renames always take precedence.
-  Nothing is automatically renamed when removing PIN columns.
-  Pseudonymized columns that were not manually renamed are suffixed when retaining PIN columns.