### PR TITLE
Drop purrr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,7 @@ Description: Tools for working with Finnish personal identity codes (PINs).
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-Imports: 
-    purrr (>= 0.2.4),
+Imports:
     stringr (>= 1.2.0),
     tibble (>= 1.3.4),
     lubridate (>= 1.7.1),

--- a/R/pseudonymize.R
+++ b/R/pseudonymize.R
@@ -39,11 +39,11 @@ pseudonymize <- function(data, key, ..., guess = FALSE,
   is_pin <- nm %in% manual
 
   if (guess) {
-    probably <- purrr::map_lgl(data, is_probably_pin)
+    probably <- vapply(data, is_probably_pin, logical(1))
     is_pin <- is_pin | probably
   }
 
-  pid_cols <- purrr::map(data[is_pin], map_to_named, key)
+  pid_cols <- lapply(data[is_pin], map_to_named, key)
 
   new_nm <- names(tidyselect::vars_rename(nm, !!!manual))
   to_rename <- is_pin & new_nm == nm


### PR DESCRIPTION
**purrr** was only used for two functions (`map()` and `map_lgl()`) with direct drop-in replacements from **base**, so it seems worth it to drop the dependency.